### PR TITLE
Support new node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/lightstep/lightstep-grafana-plugin/issues"
   },
   "engines": {
-    "node": "^9.4.0"
+    "node": ">=9.4.0"
   },
   "engineStrict": true,
   "devDependencies": {


### PR DESCRIPTION
It requires old node version.

```shell
% make build
yarn
yarn install v1.17.3
[1/5] 🔍  Validating package.json...
error lightstep-datasource@0.0.1: The engine "node" is incompatible with this module. Expected version "^9.4.0". Got "12.6.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Allow to use latest nodes. Tested against 12.6.0