### PR TITLE
Allow use dashboard variables inside query

### DIFF
--- a/src/lightstep-datasource/datasource.js
+++ b/src/lightstep-datasource/datasource.js
@@ -52,6 +52,7 @@ export class LightStepDatasource {
 
     const responses = targets.map(target => {
       const savedSearchID = this.templateSrv.replace(target.target);
+      const savedSearchName = this.templateSrv.replaceWithText(target.target);
 
       if (!savedSearchID) {
         return this.q.when(undefined);
@@ -67,9 +68,9 @@ export class LightStepDatasource {
       response.then(result => {
         if (result && result["data"]["data"]) {
           if (target.displayName) {
-            result["data"]["data"]["name"] = this.templateSrv.replace(target.displayName);
+            result["data"]["data"]["name"] = this.templateSrv.replaceWithText(target.displayName);
           } else {
-            result["data"]["data"]["name"] = savedSearchID;
+            result["data"]["data"]["name"] = savedSearchName;
           }
         }
       });

--- a/src/lightstep-datasource/datasource.js
+++ b/src/lightstep-datasource/datasource.js
@@ -51,7 +51,7 @@ export class LightStepDatasource {
     }
 
     const responses = targets.map(target => {
-      const savedSearchID = target.target;
+      const savedSearchID = this.templateSrv.replace(target.target);
 
       if (!savedSearchID) {
         return this.q.when(undefined);
@@ -67,9 +67,9 @@ export class LightStepDatasource {
       response.then(result => {
         if (result && result["data"]["data"]) {
           if (target.displayName) {
-            result["data"]["data"]["name"] = target.displayName;
+            result["data"]["data"]["name"] = this.templateSrv.replace(target.displayName);
           } else {
-            result["data"]["data"]["name"] = target.target;
+            result["data"]["data"]["name"] = savedSearchID;
           }
         }
       });


### PR DESCRIPTION
It is not possible to replace stream id via variables like `$streamid` in query edit mode.
Add interpolation to fix this problem.
It gives opportunity to use variables inside query, displayname.

Example:

![image](https://user-images.githubusercontent.com/21104/63021558-2158f180-bea1-11e9-9cdb-1de894d2beed.png)

