### PR TITLE
Fix for 403 errors in v1.2.x releases

### DIFF
--- a/src/lightstep-datasource/datasource.js
+++ b/src/lightstep-datasource/datasource.js
@@ -52,7 +52,6 @@ export class LightStepDatasource {
     this.templateSrv = templateSrv;
     this.organizationName = instanceSettings.jsonData.organizationName;
     this.projectName = instanceSettings.jsonData.projectName;
-    this.apiKey = instanceSettings.jsonData.apiKey;
   }
 
   projectNames() {
@@ -165,9 +164,9 @@ export class LightStepDatasource {
     }).then(response => {
       if (response.status === 200) {
         return { status: "success", message: "Data source is working", title: "Success" };
+      } else {
+        return { status: "failure", message: "HTTP error: " + response.status, title: "Error " }
       }
-    }).catch(error => {
-      return { status: "error", message: error, title: "Error " };
     });
   }
 

--- a/src/lightstep-datasource/partials/config.html
+++ b/src/lightstep-datasource/partials/config.html
@@ -17,12 +17,14 @@
   <div class="gf-form-inline">
     <div class="gf-form max-width-30">
       <span class="gf-form-label">API Key</span>
-      <!-- TODO(dolan) investigate "secure data json" further and whether that's the right thing to use here. -->
-      <input type="text" class="gf-form-input" ng-model="ctrl.current.jsonData.apiKey" spellcheck='false' placeholder="" required></input>
+      <input type="text" class="gf-form-input" ng-model="ctrl.current.secureJsonData.apiKey" spellcheck='false' required></input>
       <info-popover mode="right-absolute">
-        Reach out to Lightstep to generate a new Access Token.
+        Manage API Keys in Lightstep under the "Account Settings" page.
       </info-popover>
     </div>
+  </div>
+  <div class="gf-form-inline">
+    <small>API key will not be displayed if it has been set.</small>
   </div>
 </div>
 

--- a/src/lightstep-datasource/plugin.json
+++ b/src/lightstep-datasource/plugin.json
@@ -31,7 +31,7 @@
     "updated": "2022-02-16"
   },
   "dependencies": {
-    "grafanaVersion": "7.4.x",
+    "grafanaVersion": "8.x",
     "plugins": []
   },
   "routes": [

--- a/src/lightstep-graph/plugin.json
+++ b/src/lightstep-graph/plugin.json
@@ -27,7 +27,7 @@
     "updated": "2022-02-17"
   },
   "dependencies": {
-    "grafanaVersion": "7.4.x",
+    "grafanaVersion": "8.x",
     "plugins": []
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -39,7 +39,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": "7.4.x",
+    "grafanaDependency": "8.x",
     "plugins": []
   }
 }


### PR DESCRIPTION
* Allows API key (now in the `secureJsonData` field) to be set in the UI (issue #97)
* Fixes js error when there is a 403 after clicking the "Save and Test" button
* Updates plugin metadata to show the v1.2.x releases require Grafana 8+

fyi @zeitlinger @alongfield @midN
