### PR TITLE
Updated Readme link for metric plugin to be the Observability plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lightstep datasource for [streams]((https://docs.lightstep.com/docs/monitor-a-service-level-indicator-with-streams)) in Grafana. 
 
-Looking for [Lightstep metrics](https://lightstep.com/metrics/) in Grafana? Check out the [Lightstep Metrics Datasource](https://grafana.com/grafana/plugins/lightstep-metrics-datasource/).
+Looking for [Lightstep metrics](https://lightstep.com/metrics/) in Grafana? Check out the [Lightstep Observability Datasource](https://github.com/lightstep/lightstep-observability-datasource).
 
 ## Requirements
 


### PR DESCRIPTION
The PR points users to the Lightstep Observability plugin rather the metrics plugin as that is where users should go to view Lightstep Metrics in Grafana.